### PR TITLE
feat: Improve README with prominent quickstart and Discord presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,44 +30,26 @@ Claude autonomously handles complete development workflows. It analyzes your ent
 
 ## 🚀 Quick Start
 
-**New to Claude Hub?** Follow our **[10-minute Quick Start Guide](./QUICKSTART.md)** to get Claude responding to your GitHub issues using Cloudflare Tunnel - no domain or complex setup required!
-
-### Option 1: Docker Image (Recommended)
+**Follow our [10-minute Quick Start Guide](./QUICKSTART.md)** to get Claude responding to your GitHub issues using Cloudflare Tunnel - no domain or complex setup required!
 
 ```bash
-# Pull the latest image
-docker pull intelligenceassist/claude-hub:latest
-
-# Run with environment variables
-docker run -d \
-  --name claude-webhook \
-  -p 8082:3002 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -e GITHUB_TOKEN=your_github_token \
-  -e GITHUB_WEBHOOK_SECRET=your_webhook_secret \
-  -e ANTHROPIC_API_KEY=your_anthropic_key \
-  -e BOT_USERNAME=@YourBotName \
-  -e AUTHORIZED_USERS=user1,user2 \
-  intelligenceassist/claude-hub:latest
-
-# Or use Docker Compose
-wget https://raw.githubusercontent.com/intelligence-assist/claude-hub/main/docker-compose.yml
-docker compose up -d
-```
-
-### Option 2: From Source
-
-```bash
-# Clone and setup
+# 1. Clone and configure
 git clone https://github.com/intelligence-assist/claude-hub.git
 cd claude-hub
-./scripts/setup/setup-secure-credentials.sh
+cp .env.quickstart .env
+nano .env  # Add your GitHub token and bot details
 
-# Launch with Docker Compose
+# 2. Authenticate Claude (uses your Claude.ai Max subscription)
+./scripts/setup/setup-claude-interactive.sh
+
+# 3. Start the service
 docker compose up -d
+
+# 4. Create a tunnel (see quickstart guide for details)
+cloudflared tunnel --url http://localhost:3002
 ```
 
-Service runs on `http://localhost:8082` by default.
+That's it! Your bot is ready to use. See the **[complete quickstart guide](./QUICKSTART.md)** for detailed instructions and webhook setup.
 
 ## Autonomous Workflow Capabilities
 
@@ -220,7 +202,7 @@ AWS_SECRET_ACCESS_KEY=xxx
 Integrate Claude without GitHub webhooks:
 
 ```bash
-curl -X POST http://localhost:8082/api/claude \
+curl -X POST http://localhost:3002/api/claude \
   -H "Content-Type: application/json" \
   -d '{
     "repoFullName": "owner/repo",
@@ -313,7 +295,7 @@ CLAUDE_CONTAINER_IMAGE=claudecode:latest
 
 ### Health Check
 ```bash
-curl http://localhost:8082/health
+curl http://localhost:3002/health
 ```
 
 ### Logs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Claude GitHub Webhook
 
+[![Discord](https://img.shields.io/discord/1377708770209304676?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/yb7hwQjTFg)
 [![Main Pipeline](https://github.com/intelligence-assist/claude-hub/actions/workflows/main.yml/badge.svg)](https://github.com/intelligence-assist/claude-hub/actions/workflows/main.yml)
 [![Security Scans](https://github.com/intelligence-assist/claude-hub/actions/workflows/security.yml/badge.svg)](https://github.com/intelligence-assist/claude-hub/actions/workflows/security.yml)
 [![Jest Tests](https://img.shields.io/badge/tests-jest-green)](test/README.md)
@@ -8,6 +9,8 @@
 [![Docker Hub](https://img.shields.io/docker/v/intelligenceassist/claude-hub?label=docker)](https://hub.docker.com/r/intelligenceassist/claude-hub)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+🚀 **[Quick Start Guide](./QUICKSTART.md)** | 💬 **[Discord](https://discord.gg/yb7hwQjTFg)** | 📚 **[Documentation](https://docs.intelligence-assist.com/claude-hub/overview)** | 📖 **[Complete Setup](./docs/complete-workflow.md)** | 🔐 **[Authentication](./docs/claude-authentication-guide.md)**
 
 ![Claude GitHub Webhook brain factory - AI brain connected to GitHub octocat via assembly line of Docker containers](./assets/brain_factory.png)
 
@@ -24,6 +27,47 @@ Deploy Claude Code as a fully autonomous GitHub bot. Create your own bot account
 ```
 
 Claude autonomously handles complete development workflows. It analyzes your entire repository, implements features from scratch, conducts thorough code reviews, manages pull requests, monitors CI/CD pipelines, and responds to automated feedback - all without human intervention. No context switching. No manual oversight required. Just seamless autonomous development where you work.
+
+## 🚀 Quick Start
+
+**New to Claude Hub?** Follow our **[10-minute Quick Start Guide](./QUICKSTART.md)** to get Claude responding to your GitHub issues using Cloudflare Tunnel - no domain or complex setup required!
+
+### Option 1: Docker Image (Recommended)
+
+```bash
+# Pull the latest image
+docker pull intelligenceassist/claude-hub:latest
+
+# Run with environment variables
+docker run -d \
+  --name claude-webhook \
+  -p 8082:3002 \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e GITHUB_TOKEN=your_github_token \
+  -e GITHUB_WEBHOOK_SECRET=your_webhook_secret \
+  -e ANTHROPIC_API_KEY=your_anthropic_key \
+  -e BOT_USERNAME=@YourBotName \
+  -e AUTHORIZED_USERS=user1,user2 \
+  intelligenceassist/claude-hub:latest
+
+# Or use Docker Compose
+wget https://raw.githubusercontent.com/intelligence-assist/claude-hub/main/docker-compose.yml
+docker compose up -d
+```
+
+### Option 2: From Source
+
+```bash
+# Clone and setup
+git clone https://github.com/intelligence-assist/claude-hub.git
+cd claude-hub
+./scripts/setup/setup-secure-credentials.sh
+
+# Launch with Docker Compose
+docker compose up -d
+```
+
+Service runs on `http://localhost:8082` by default.
 
 ## Autonomous Workflow Capabilities
 
@@ -64,44 +108,6 @@ Claude autonomously handles complete development workflows. It analyzes your ent
 - Container isolation with minimal permissions
 - Fine-grained GitHub token scoping
 
-## Quick Start
-
-### Option 1: Docker Image (Recommended)
-
-```bash
-# Pull the latest image
-docker pull intelligenceassist/claude-hub:latest
-
-# Run with environment variables
-docker run -d \
-  --name claude-webhook \
-  -p 8082:3002 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -e GITHUB_TOKEN=your_github_token \
-  -e GITHUB_WEBHOOK_SECRET=your_webhook_secret \
-  -e ANTHROPIC_API_KEY=your_anthropic_key \
-  -e BOT_USERNAME=@YourBotName \
-  -e AUTHORIZED_USERS=user1,user2 \
-  intelligenceassist/claude-hub:latest
-
-# Or use Docker Compose
-wget https://raw.githubusercontent.com/intelligence-assist/claude-hub/main/docker-compose.yml
-docker compose up -d
-```
-
-### Option 2: From Source
-
-```bash
-# Clone and setup
-git clone https://github.com/intelligence-assist/claude-hub.git
-cd claude-hub
-./scripts/setup/setup-secure-credentials.sh
-
-# Launch with Docker Compose
-docker compose up -d
-```
-
-Service runs on `http://localhost:8082` by default.
 
 ## Bot Account Setup
 


### PR DESCRIPTION
## Summary
- Add Discord badge with live member count for better community visibility
- Make QUICKSTART.md more prominent with top navigation and callout  
- Simplify Quick Start section to use .env file approach
- Fix port inconsistencies throughout README

## Changes
- Added Discord presence badge showing live member count at top of badges section
- Moved Quick Start section higher in README (right after "What This Does")
- Replaced confusing docker run command with cleaner 4-step .env file setup
- Aligned README Quick Start with QUICKSTART.md approach for consistency
- Fixed port references (8082 → 3002) to match actual default
- Updated navigation bar with Quick Start Guide as the first item
- Included actual Discord invite and documentation URLs

## Motivation
Based on user feedback:
1. The quickstart guide should be more prominent
2. The Discord community should be highlighted at the top
3. The docker run command with many env vars is confusing - .env file is cleaner
4. Having two different quickstart approaches creates confusion

This helps new users:
- Find the quickstart guide immediately
- See the active community presence  
- Get up and running faster with a simpler, consistent approach

## Test Plan
- [x] Verify all links work correctly
- [x] Discord badge displays properly with member count
- [x] Navigation flows logically for new users
- [x] Port references are consistent (3002)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)