### PR TITLE
docs: Clarify that GitHub PAT should be from bot account

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,8 +11,8 @@ Get Claude responding to your GitHub issues in minutes using Cloudflare Tunnel.
 ## Step 1: Create a GitHub Bot Account
 
 1. Sign out of GitHub and create a new account for your bot (e.g., `YourProjectBot`)
-2. In your main account, create a [Personal Access Token](https://github.com/settings/tokens) with `repo` and `write` permissions
-3. Add the bot account as a collaborator to your repositories
+2. Sign in to your bot account and create a [Personal Access Token](https://github.com/settings/tokens) with `repo` and `write` permissions
+3. Add the bot account as a collaborator to your repositories from your main account
 
 ## Step 2: Clone and Configure
 
@@ -29,7 +29,7 @@ nano .env
 ```
 
 Required values:
-- `GITHUB_TOKEN`: Your GitHub Personal Access Token
+- `GITHUB_TOKEN`: Your bot account's GitHub Personal Access Token
 - `GITHUB_WEBHOOK_SECRET`: Generate with `openssl rand -hex 32`
 - `BOT_USERNAME`: Your bot's GitHub username (e.g., `@YourProjectBot`)
 - `BOT_EMAIL`: Your bot's email

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ That's it! Your bot is ready to use. See the **[complete quickstart guide](./QUI
 **Current Setup**: You need to create your own GitHub bot account:
 
 1. **Create a dedicated GitHub account** for your bot (e.g., `MyProjectBot`)
-2. **Generate a Personal Access Token** with repository permissions
+2. **Generate a Personal Access Token** from the bot account with repository permissions
 3. **Configure the bot username** in your environment variables
 4. **Add the bot account** as a collaborator to your repositories
 
@@ -117,7 +117,7 @@ That's it! Your bot is ready to use. See the **[complete quickstart guide](./QUI
 # Core settings  
 BOT_USERNAME=YourBotName              # GitHub bot account username (create your own bot account)
 GITHUB_WEBHOOK_SECRET=<generated>     # Webhook validation
-GITHUB_TOKEN=<fine-grained-pat>       # Repository access (from your bot account)
+GITHUB_TOKEN=<fine-grained-pat>       # Repository access (PAT from your bot account)
 
 # Claude Authentication - Choose ONE method:
 


### PR DESCRIPTION
## Summary
- Updated README.md and QUICKSTART.md to clearly specify that the GitHub PAT should be created from the bot account
- Removed redundant clarification about "not main account" as it's already implied

## Test plan
[x] Documentation changes only - no code changes
[x] Reviewed for clarity and accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)