### PR TITLE
Fix PR review markdown formatting issues

### DIFF
--- a/src/controllers/githubController.ts
+++ b/src/controllers/githubController.ts
@@ -1375,6 +1375,31 @@ Create a single comprehensive review comment with all feedback.
 6. **Complete your review** with an appropriate event type (APPROVE, REQUEST_CHANGES, or COMMENT)
 7. **Include commit SHA** - Always include "Reviewed at commit: ${commitSha}" in your final review comment
 
+## CRITICAL: Markdown Formatting Requirements
+
+**IMPORTANT**: When writing your review comments and responses:
+- Return clean, human-readable markdown that GitHub will render correctly
+- Do NOT escape or encode special characters like newlines (\\n), quotes, or backslashes
+- Use proper markdown syntax directly:
+  - Use actual bullet points: * or - (not escaped versions)
+  - Use actual code blocks with triple backticks (not escaped)
+  - Use actual line breaks (press Enter, don't write \\n)
+  - Use actual quotes " or ' (not escaped versions like \\" or \\')
+- Your output should look like normal markdown text, NOT escaped strings
+- GitHub expects standard markdown - write it naturally as you would in any markdown editor
+
+Example of CORRECT formatting:
+* This is a bullet point
+* Another bullet point with \`inline code\`
+
+\`\`\`javascript
+// This is a code block
+const example = "string";
+\`\`\`
+
+Example of INCORRECT formatting (DO NOT DO THIS):
+\\* This is a bullet point\\n\\* Another bullet point with \\\`inline code\\\`\\n\\n\\\`\\\`\\\`javascript\\n// This is a code block\\nconst example = \\"string\\";\\n\\\`\\\`\\\`
+
 Please perform a comprehensive review of PR #${prNumber} in repository ${repoFullName}.`;
 }
 

--- a/src/services/claudeService.ts
+++ b/src/services/claudeService.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import { execFile } from 'child_process';
 import path from 'path';
 import { createLogger } from '../utils/logger';
-import { sanitizeBotMentions } from '../utils/sanitize';
+import { sanitizeBotMentions, unescapeMarkdown } from '../utils/sanitize';
 import secureCredentials from '../utils/secureCredentials';
 import type {
   ClaudeCommandOptions,
@@ -79,7 +79,8 @@ Since this is a test environment, I'm providing a simulated response. In product
 For real functionality, please configure valid GitHub and Claude API tokens.`;
 
       // Always sanitize responses, even in test mode
-      return sanitizeBotMentions(testResponse);
+      const unescapedResponse = unescapeMarkdown(testResponse);
+      return sanitizeBotMentions(unescapedResponse);
     }
 
     // Build Docker image if it doesn't exist
@@ -194,6 +195,9 @@ For real functionality, please configure valid GitHub and Claude API tokens.`;
           );
         }
       }
+
+      // Unescape any markdown formatting that may have been escaped by Claude
+      responseText = unescapeMarkdown(responseText);
 
       // Sanitize response to prevent infinite loops by removing bot mentions
       responseText = sanitizeBotMentions(responseText);

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -101,3 +101,43 @@ export function sanitizeEnvironmentValue(key: string, value: string): string {
 
   return isSensitive ? '[REDACTED]' : value;
 }
+
+/**
+ * Unescapes markdown formatting that may have been escaped by Claude
+ * This is a fallback for when Claude escapes markdown despite instructions
+ */
+export function unescapeMarkdown(text: string): string {
+  if (!text) return text;
+
+  // Replace escaped newlines with actual newlines
+  let unescaped = text.replace(/\\n/g, '\n');
+
+  // Replace escaped quotes
+  unescaped = unescaped.replace(/\\"/g, '"');
+  unescaped = unescaped.replace(/\\'/g, "'");
+
+  // Replace escaped backticks (for code blocks)
+  unescaped = unescaped.replace(/\\`/g, '`');
+
+  // Replace escaped backslashes (but be careful not to double-unescape)
+  // Only replace \\ with \ if it's not followed by another escape sequence
+  unescaped = unescaped.replace(/\\\\(?![nrt"`'])/g, '\\');
+
+  // Replace escaped asterisks and other markdown characters
+  unescaped = unescaped.replace(/\\\*/g, '*');
+  unescaped = unescaped.replace(/\\_/g, '_');
+  unescaped = unescaped.replace(/\\-/g, '-');
+  unescaped = unescaped.replace(/\\#/g, '#');
+  unescaped = unescaped.replace(/\\>/g, '>');
+  unescaped = unescaped.replace(/\\\[/g, '[');
+  unescaped = unescaped.replace(/\\\]/g, ']');
+  unescaped = unescaped.replace(/\\\(/g, '(');
+  unescaped = unescaped.replace(/\\\)/g, ')');
+
+  // Log if unescaping occurred
+  if (unescaped !== text) {
+    logger.info('Unescaped markdown formatting in text');
+  }
+
+  return unescaped;
+}


### PR DESCRIPTION
## Summary
Fixes escaping issues in PR review output where Claude was returning escaped markdown characters instead of clean markdown that GitHub can render properly.

## Problem
PR reviews contained escaped characters like `\n`, `\"`, `\*`, etc. instead of proper markdown formatting, making the reviews difficult to read.

## Solution
1. **Enhanced PR Review Prompt**: Added explicit markdown formatting instructions with clear examples of correct vs incorrect formatting
2. **Post-Processing Function**: Implemented `unescapeMarkdown()` utility as a fallback to handle any escaped markdown
3. **Service Integration**: Applied markdown unescaping to all Claude responses before posting to GitHub
4. **Comprehensive Testing**: Added 8 test cases covering various escaping scenarios

## Changes
- `src/controllers/githubController.ts`: Enhanced PR review prompt with markdown formatting requirements
- `src/services/claudeService.ts`: Applied `unescapeMarkdown()` to all Claude responses  
- `src/utils/sanitize.ts`: Added `unescapeMarkdown()` utility function
- `test/unit/utils/sanitize.test.ts`: Added comprehensive test coverage

## Test Plan
- [x] All existing tests pass
- [x] New markdown unescaping tests pass (8 test cases)
- [x] TypeScript compilation successful
- [x] ESLint and Prettier checks pass

## Result
GitHub will now receive properly formatted markdown that renders correctly instead of escaped strings, improving the readability and usability of PR reviews.

🤖 Generated with [Claude Code](https://claude.ai/code)